### PR TITLE
fix: force package.json update to move dev deps to deps

### DIFF
--- a/packages/xerox-stylelint-config/package.json
+++ b/packages/xerox-stylelint-config/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "description": "Stylelint shareable configuration for Xerox projects.",
   "keywords": [
-    "xerox",
     "stylelint",
-    "stylelint-config"
+    "stylelint-config",
+    "xerox"
   ],
   "main": "index.json",
   "repository": "git@github.com:xeroxinteractive/config.git",


### PR DESCRIPTION
It was previously done as a chore, but never got deployed, and it turns out it is critical