### PR TITLE
chore: force yarn install

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,7 +3602,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5401,7 +5401,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6871,11 +6871,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6884,32 +6879,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6990,11 +6963,6 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/eslint-config@3.1.9-next.2`

<details>
  <summary>Changelog</summary>

  #### Fix
  
  - chore: force yarn install [#501](https://github.com/xeroxinteractive/config/pull/501) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  - ci: tweaks [#500](https://github.com/xeroxinteractive/config/pull/500) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  - ci: lerna yarn caching [#499](https://github.com/xeroxinteractive/config/pull/499) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  - `@xerox/browserslist-config`, `@xerox/commitlint-config`, `@xerox/eslint-config`, `@xerox/prettier-config`, `@xerox/semantic-release-config`, `@xerox/stylelint-config`
    - Al react 17 [#496](https://github.com/xeroxinteractive/config/pull/496) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Dependencies
  
  - chore(deps): bump semantic-release-slack-bot from 1.6.2 to 1.7.0 [#497](https://github.com/xeroxinteractive/config/pull/497) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.2.0 to 2.2.1 [#498](https://github.com/xeroxinteractive/config/pull/498) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript from 4.0.5 to 4.1.2 [#490](https://github.com/xeroxinteractive/config/pull/490) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.8.1 to 4.8.2 [#495](https://github.com/xeroxinteractive/config/pull/495) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.4.0 to 10.4.2 [#494](https://github.com/xeroxinteractive/config/pull/494) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.13.0 to 7.14.0 [#492](https://github.com/xeroxinteractive/config/pull/492) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.1.2 to 2.2.0 [#491](https://github.com/xeroxinteractive/config/pull/491) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.3.0 to 10.4.0 [#489](https://github.com/xeroxinteractive/config/pull/489) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.3.0 to 10.4.0 [#488](https://github.com/xeroxinteractive/config/pull/488) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @semantic-release/github from 7.1.2 to 7.2.0 [#487](https://github.com/xeroxinteractive/config/pull/487) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump stylelint from 13.7.2 to 13.8.0 [#485](https://github.com/xeroxinteractive/config/pull/485) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.8.0 to 4.8.1 [#486](https://github.com/xeroxinteractive/config/pull/486) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.8.0 to 4.8.1 [#484](https://github.com/xeroxinteractive/config/pull/484) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.7.0 to 4.8.0 [#482](https://github.com/xeroxinteractive/config/pull/482) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @semantic-release/npm from 7.0.6 to 7.0.8 [#483](https://github.com/xeroxinteractive/config/pull/483) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.7.0 to 4.8.0 [#481](https://github.com/xeroxinteractive/config/pull/481) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @semantic-release/github from 7.1.1 to 7.1.2 [#479](https://github.com/xeroxinteractive/config/pull/479) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 30.7.7 to 30.7.8 [#480](https://github.com/xeroxinteractive/config/pull/480) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.1.0 to 24.1.3 [#478](https://github.com/xeroxinteractive/config/pull/478) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@xerox/eslint-config`
    - chore(deps-dev): bump @types/react from 16.9.56 to 17.0.0 [#493](https://github.com/xeroxinteractive/config/pull/493) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - chore(deps-dev): bump react from 16.14.0 to 17.0.1 [#437](https://github.com/xeroxinteractive/config/pull/437) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### ⚠️ Pushed to `next`
  
  - `@xerox/eslint-config`
    - feat(react): add react-testing-library plugin ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Andrew Leedham ([@AndrewLeedham](https://github.com/AndrewLeedham))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
