### PR TITLE
Create Xerox CLI package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# CLI build folder
+packages/xerox-cli/build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,9 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "prettier.ignorePath": ".gitignore",
+  "eslint.options": {
+    "ignorePath": ".gitignore"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "yarn": ">=1.15.2"
   },
   "scripts": {
-    "lint": "eslint ./packages/**/*.js && prettier ./**/*.json --check",
-    "format": "eslint ./packages/**/*.js --format && prettier ./**/*.json --write",
+    "lint": "eslint ./packages/**/*.js && prettier ./**/*.json --check --ignore-path .gitignore",
+    "format": "eslint ./packages/**/*.js --format && prettier ./**/*.json --write --ignore-path .gitignore",
     "deploy": "auto shipit",
     "test": "jest --testPathIgnorePatterns packages && lerna exec jest -- --passWithNoTests"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "yarn": ">=1.15.2"
   },
   "scripts": {
-    "lint": "eslint ./packages/**/*.js && prettier ./**/*.json --check --ignore-path .gitignore",
+    "lint": "eslint ./packages/**/*.js && prettier ./**/*.json --check --ignore-path .gitignore && lerna run lint",
     "format": "eslint ./packages/**/*.js --format && prettier ./**/*.json --write --ignore-path .gitignore",
     "deploy": "auto shipit",
     "test": "jest --testPathIgnorePatterns packages && lerna exec jest -- --passWithNoTests"

--- a/packages/xerox-cli/bin/x.js
+++ b/packages/xerox-cli/bin/x.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/xerox-cli/package.json
+++ b/packages/xerox-cli/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@xerox/cli",
+  "version": "0.0.0",
+  "description": "Shared CLI for Xerox projects.",
+  "keywords": [
+    "xerox",
+    "cli"
+  ],
+  "bin": {
+    "x": "./bin/x.js"
+  },
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "tsc",
+    "lint": "tsc --noEmit"
+  },
+  "files": [
+    "bin/",
+    "build/"
+  ],
+  "repository": "git@github.com:xeroxinteractive/config.git",
+  "homepage": "https://github.com/xeroxinteractive/config/blob/master/packages/xerox-cli",
+  "author": "Andrew Leedham <andrew.leedham@xerox.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "^4.1.2"
+  },
+  "dependencies": {
+    "find-up": "^5.0.0"
+  }
+}

--- a/packages/xerox-cli/package.json
+++ b/packages/xerox-cli/package.json
@@ -29,6 +29,7 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "find-up": "^5.0.0"
+    "find-up": "^5.0.0",
+    "chalk": "^4.1.0"
   }
 }

--- a/packages/xerox-cli/source/index.ts
+++ b/packages/xerox-cli/source/index.ts
@@ -1,9 +1,12 @@
 import findUp from 'find-up';
 import path from 'path';
+import chalk from 'chalk';
 
 const configPath = findUp.sync('x-cli.config.js');
 if (configPath) {
   const {run} = require(configPath);
   process.chdir(path.dirname(configPath));
   run();
+} else {
+  console.warn(chalk.yellow('No Xerox CLI configuration found. Make sure your current working directory is within a participating Xerox project.'));
 }

--- a/packages/xerox-cli/source/index.ts
+++ b/packages/xerox-cli/source/index.ts
@@ -1,0 +1,9 @@
+import findUp from 'find-up';
+import path from 'path';
+
+const configPath = findUp.sync('x-cli.config.js');
+if (configPath) {
+  const {run} = require(configPath);
+  process.chdir(path.dirname(configPath));
+  run();
+}

--- a/packages/xerox-cli/tsconfig.json
+++ b/packages/xerox-cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "outDir": "build"
+  },
+  "include": ["source"]
+}

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,0 @@
-const path = require('path');
-
-module.exports = {
-  extends: '../xerox-semantic-release-config/npm-next.js',
-  commitPaths: ['../../LICENSE', './*'],
-  tagFormat: `${path.parse(process.cwd()).name}-\${version}`,
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,7 +3609,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5387,7 +5387,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6857,11 +6857,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6870,32 +6865,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6976,11 +6949,6 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -7839,7 +7807,6 @@ npm@^6.14.9:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7854,7 +7821,6 @@ npm@^6.14.9:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -7873,14 +7839,8 @@ npm@^6.14.9:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/cli@0.1.0-next.0`
`@xerox/commitlint-config@2.2.0-next.0`
`@xerox/eslint-config@3.2.0-next.0`
`@xerox/semantic-release-config@2.4.0-next.0`

<details>
  <summary>Changelog</summary>

  #### Feature
  
  - `@xerox/cli`
    - Create Xerox CLI package [#614](https://github.com/xeroxinteractive/config/pull/614) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Dependencies
  
  - chore(deps-dev): bump @auto-it/slack from 10.16.5 to 10.16.6 [#613](https://github.com/xeroxinteractive/config/pull/613) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.16.5 to 10.16.6 [#612](https://github.com/xeroxinteractive/config/pull/612) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-import-resolver-typescript from 2.3.0 to 2.4.0 [#611](https://github.com/xeroxinteractive/config/pull/611) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.1.3 to 24.1.5 [#610](https://github.com/xeroxinteractive/config/pull/610) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 32.0.1 to 32.0.2 [#609](https://github.com/xeroxinteractive/config/pull/609) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.15.0 to 4.15.1 [#608](https://github.com/xeroxinteractive/config/pull/608) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 32.0.0 to 32.0.1 [#607](https://github.com/xeroxinteractive/config/pull/607) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.15.0 to 4.15.1 [#606](https://github.com/xeroxinteractive/config/pull/606) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.6.1 to 32.0.0 in /packages/xerox-eslint-config [#605](https://github.com/xeroxinteractive/config/pull/605) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.19.0 to 7.20.0 [#603](https://github.com/xeroxinteractive/config/pull/603) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/react from 17.0.1 to 17.0.2 [#602](https://github.com/xeroxinteractive/config/pull/602) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.16.0 to 10.16.5 [#601](https://github.com/xeroxinteractive/config/pull/601) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump stylelint from 13.9.0 to 13.10.0 [#600](https://github.com/xeroxinteractive/config/pull/600) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.16.0 to 10.16.5 [#599](https://github.com/xeroxinteractive/config/pull/599) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.1.4 to 4.1.5 [#598](https://github.com/xeroxinteractive/config/pull/598) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.1.3 to 4.1.4 [#597](https://github.com/xeroxinteractive/config/pull/597) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump stylelint-scss from 3.18.0 to 3.19.0 [#592](https://github.com/xeroxinteractive/config/pull/592) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump husky from 4.3.8 to 5.0.9 in /packages/xerox-commitlint-config [#593](https://github.com/xeroxinteractive/config/pull/593) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.14.2 to 4.15.0 [#594](https://github.com/xeroxinteractive/config/pull/594) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.14.2 to 4.15.0 [#596](https://github.com/xeroxinteractive/config/pull/596) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.6.0 to 31.6.1 [#591](https://github.com/xeroxinteractive/config/pull/591) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.15.0 to 10.16.0 [#589](https://github.com/xeroxinteractive/config/pull/589) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.15.0 to 10.16.0 [#590](https://github.com/xeroxinteractive/config/pull/590) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.13.4 to 10.15.0 [#587](https://github.com/xeroxinteractive/config/pull/587) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.13.4 to 10.15.0 [#588](https://github.com/xeroxinteractive/config/pull/588) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/react from 17.0.0 to 17.0.1 [#586](https://github.com/xeroxinteractive/config/pull/586) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.13.3 to 10.13.4 [#584](https://github.com/xeroxinteractive/config/pull/584) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump semantic-release-slack-bot from 1.7.0 to 2.1.0 in /packages/xerox-semantic-release-config [#581](https://github.com/xeroxinteractive/config/pull/581) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.14.1 to 4.14.2 [#582](https://github.com/xeroxinteractive/config/pull/582) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.14.1 to 4.14.2 [#583](https://github.com/xeroxinteractive/config/pull/583) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.13.3 to 10.13.4 [#585](https://github.com/xeroxinteractive/config/pull/585) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.18.0 to 7.19.0 [#578](https://github.com/xeroxinteractive/config/pull/578) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump browserslist from 4.16.1 to 4.16.3 [#577](https://github.com/xeroxinteractive/config/pull/577) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.4.0 to 31.6.0 [#579](https://github.com/xeroxinteractive/config/pull/579) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.13.2 to 10.13.3 [#575](https://github.com/xeroxinteractive/config/pull/575) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.13.2 to 10.13.3 [#576](https://github.com/xeroxinteractive/config/pull/576) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.3.3 to 31.4.0 [#574](https://github.com/xeroxinteractive/config/pull/574) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.12.2 to 10.13.2 [#572](https://github.com/xeroxinteractive/config/pull/572) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.14.0 to 4.14.1 [#569](https://github.com/xeroxinteractive/config/pull/569) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.3.2 to 31.3.3 [#570](https://github.com/xeroxinteractive/config/pull/570) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.12.2 to 10.13.2 [#571](https://github.com/xeroxinteractive/config/pull/571) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.14.0 to 4.14.1 [#573](https://github.com/xeroxinteractive/config/pull/573) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.0.8 to 31.3.2 [#568](https://github.com/xeroxinteractive/config/pull/568) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.11.0 to 10.12.2 [#567](https://github.com/xeroxinteractive/config/pull/567) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.11.0 to 10.12.2 [#566](https://github.com/xeroxinteractive/config/pull/566) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.10.0 to 10.11.0 [#564](https://github.com/xeroxinteractive/config/pull/564) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.10.0 to 10.11.0 [#562](https://github.com/xeroxinteractive/config/pull/562) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump stylelint from 13.8.0 to 13.9.0 [#563](https://github.com/xeroxinteractive/config/pull/563) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.0.7 to 31.0.8 [#565](https://github.com/xeroxinteractive/config/pull/565) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @semantic-release/npm from 7.0.9 to 7.0.10 [#558](https://github.com/xeroxinteractive/config/pull/558) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.0.5 to 31.0.7 [#557](https://github.com/xeroxinteractive/config/pull/557) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.13.0 to 4.14.0 [#560](https://github.com/xeroxinteractive/config/pull/560) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.13.0 to 4.14.0 [#559](https://github.com/xeroxinteractive/config/pull/559) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-config-prettier from 7.1.0 to 7.2.0 [#561](https://github.com/xeroxinteractive/config/pull/561) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.0.5 to 31.0.6 [#552](https://github.com/xeroxinteractive/config/pull/552) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.9.1 to 10.10.0 [#555](https://github.com/xeroxinteractive/config/pull/555) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.17.0 to 7.18.0 [#553](https://github.com/xeroxinteractive/config/pull/553) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.6.1 to 10.10.0 [#554](https://github.com/xeroxinteractive/config/pull/554) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump husky from 4.3.7 to 4.3.8 [#556](https://github.com/xeroxinteractive/config/pull/556) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 31.0.3 to 31.0.5 [#549](https://github.com/xeroxinteractive/config/pull/549) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.6.1 to 10.9.1 [#551](https://github.com/xeroxinteractive/config/pull/551) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.6.0 to 10.6.1 [#547](https://github.com/xeroxinteractive/config/pull/547) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.6.0 to 10.6.1 [#548](https://github.com/xeroxinteractive/config/pull/548) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.5.1 to 10.6.0 [#541](https://github.com/xeroxinteractive/config/pull/541) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.12.0 to 4.13.0 [#544](https://github.com/xeroxinteractive/config/pull/544) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.12.0 to 4.13.0 [#542](https://github.com/xeroxinteractive/config/pull/542) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.5.1 to 10.6.0 [#545](https://github.com/xeroxinteractive/config/pull/545) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.5.0 to 10.5.1 [#539](https://github.com/xeroxinteractive/config/pull/539) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.5.0 to 10.5.1 [#540](https://github.com/xeroxinteractive/config/pull/540) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump globby from 11.0.1 to 11.0.2 [#537](https://github.com/xeroxinteractive/config/pull/537) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump husky from 4.3.6 to 4.3.7 [#538](https://github.com/xeroxinteractive/config/pull/538) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump browserslist from 4.16.0 to 4.16.1 [#536](https://github.com/xeroxinteractive/config/pull/536) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-react from 7.21.5 to 7.22.0 [#532](https://github.com/xeroxinteractive/config/pull/532) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.11.1 to 4.12.0 [#533](https://github.com/xeroxinteractive/config/pull/533) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-prettier from 3.3.0 to 3.3.1 [#534](https://github.com/xeroxinteractive/config/pull/534) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.4.2 to 10.5.0 [#531](https://github.com/xeroxinteractive/config/pull/531) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.10.0 to 4.12.0 [#535](https://github.com/xeroxinteractive/config/pull/535) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 30.7.8 to 30.7.13 [#528](https://github.com/xeroxinteractive/config/pull/528) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.4.2 to 10.5.0 [#525](https://github.com/xeroxinteractive/config/pull/525) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-config-prettier from 7.0.0 to 7.1.0 [#523](https://github.com/xeroxinteractive/config/pull/523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump node-notifier from 8.0.0 to 8.0.1 [#526](https://github.com/xeroxinteractive/config/pull/526) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.10.0 to 4.11.1 [#527](https://github.com/xeroxinteractive/config/pull/527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.15.0 to 7.17.0 [#529](https://github.com/xeroxinteractive/config/pull/529) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.9.1 to 4.10.0 [#520](https://github.com/xeroxinteractive/config/pull/520) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-prettier from 3.2.0 to 3.3.0 [#517](https://github.com/xeroxinteractive/config/pull/517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.1.2 to 4.1.3 [#516](https://github.com/xeroxinteractive/config/pull/516) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump husky from 4.3.5 to 4.3.6 [#518](https://github.com/xeroxinteractive/config/pull/518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump browserslist from 4.15.0 to 4.16.0 [#514](https://github.com/xeroxinteractive/config/pull/514) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump ini from 1.3.5 to 1.3.8 [#515](https://github.com/xeroxinteractive/config/pull/515) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.9.1 to 4.10.0 [#519](https://github.com/xeroxinteractive/config/pull/519) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump husky from 4.3.0 to 4.3.5 [#511](https://github.com/xeroxinteractive/config/pull/511) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.9.0 to 4.9.1 [#512](https://github.com/xeroxinteractive/config/pull/512) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.9.0 to 4.9.1 [#513](https://github.com/xeroxinteractive/config/pull/513) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-config-prettier from 6.15.0 to 7.0.0 in /packages/xerox-eslint-config [#510](https://github.com/xeroxinteractive/config/pull/510) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.14.0 to 7.15.0 [#508](https://github.com/xeroxinteractive/config/pull/508) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-prettier from 3.1.4 to 3.2.0 [#506](https://github.com/xeroxinteractive/config/pull/506) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @semantic-release/npm from 7.0.8 to 7.0.9 [#507](https://github.com/xeroxinteractive/config/pull/507) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump browserslist from 4.14.7 to 4.15.0 [#505](https://github.com/xeroxinteractive/config/pull/505) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.8.2 to 4.9.0 [#503](https://github.com/xeroxinteractive/config/pull/503) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.8.2 to 4.9.0 [#504](https://github.com/xeroxinteractive/config/pull/504) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@xerox/eslint-config`
    - chore(deps): bump eslint-plugin-jsdoc from 31.6.1 to 32.0.0 [#604](https://github.com/xeroxinteractive/config/pull/604) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - chore(deps): bump eslint-plugin-jsdoc from 30.7.13 to 31.0.3 [#546](https://github.com/xeroxinteractive/config/pull/546) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - chore(deps): bump eslint-config-prettier from 6.15.0 to 7.0.0 [#509](https://github.com/xeroxinteractive/config/pull/509) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@xerox/commitlint-config`
    - chore(deps): bump husky from 4.3.8 to 5.0.9 [#595](https://github.com/xeroxinteractive/config/pull/595) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@xerox/semantic-release-config`
    - chore(deps): bump semantic-release-slack-bot from 1.7.0 to 2.1.0 [#580](https://github.com/xeroxinteractive/config/pull/580) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Andrew Leedham ([@AndrewLeedham](https://github.com/AndrewLeedham))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
