### PR TITLE
Seperate out jest config

### DIFF
--- a/packages/xerox-eslint-config/README.md
+++ b/packages/xerox-eslint-config/README.md
@@ -23,6 +23,7 @@ npm install eslint@5.12.1 @xerox/eslint-config --save-dev
     "@xerox",
     "@xerox/eslint-config/typescript", // Optional
     "@xerox/eslint-config/react" // Optional
+    "@xerox/eslint-config/jest" // Optional
   ]
 }
 ```
@@ -33,7 +34,10 @@ The base eslint configuration i.e. `"extends": ["@xerox"]` includes rules for Je
 ### xerox/typescript
 The typescript eslint configuration i.e. `"extends": ["@xerox/eslint-config/typescript"]` includes various TypeScript related rules, as well as swapping the default parser in order for eslint to work with TypeScript. You should call eslint using `--ext .js,.ts`, add `.jsx` and/or `.tsx` if necessary. This also adds a JSDoc requirement for only TypeScript files, `.js` and `test.{js,ts}` files are excluded, this allows you to progressively convert from TS to JS without having to add JSdoc to all the old JS source. These JSDoc rules are setup to mimick TSDoc, eslint-plugin-tsdoc doesn't yet exist, so this is a workaround, try to follow the example set out [here](https://github.com/Microsoft/tsdoc).
 ### xerox/react
-The react eslint configuration i.e. `"extends": ["@xerox/eslint-config/react"]` enables jsx and includes the react reccomended settings from eslint-plugin-react, this sub-config needs some fleshing out.
+The react eslint configuration i.e. `"extends": ["@xerox/eslint-config/react"]` enables jsx and includes the react recommended settings from eslint-plugin-react, this sub-config needs some fleshing out.
+
+### xerox/jest
+The jest eslint configuration i.e. `"extends": ["@xerox/eslint-config/jest"]` includes the jest recommended settings from eslint-plugin-jest.
 
 ---
 [LICENSE][license-link] | [CHANGELOG][changelog-link]

--- a/packages/xerox-eslint-config/__tests__/configs.test.js
+++ b/packages/xerox-eslint-config/__tests__/configs.test.js
@@ -1,6 +1,6 @@
 const CLIEngine = require('eslint').CLIEngine;
 
-test.each(['index.js', 'react.js', 'typescript.js'])(
+test.each(['index.js', 'react.js', 'typescript.js', 'jest.js'])(
   '%s config valid',
   (filename) => {
     expect(

--- a/packages/xerox-eslint-config/index.js
+++ b/packages/xerox-eslint-config/index.js
@@ -1,11 +1,6 @@
 module.exports = {
-  plugins: ['jest', 'prettier', 'import'],
-  extends: [
-    'plugin:jest/recommended',
-    'prettier',
-    'plugin:import/errors',
-    'plugin:import/warnings',
-  ],
+  plugins: ['prettier', 'import'],
+  extends: ['prettier', 'plugin:import/errors', 'plugin:import/warnings'],
 
   env: {
     node: true,

--- a/packages/xerox-eslint-config/jest.js
+++ b/packages/xerox-eslint-config/jest.js
@@ -1,0 +1,4 @@
+module.exports = {
+  plugins: ['jest'],
+  extends: ['plugin:jest/recommended'],
+};

--- a/packages/xerox-eslint-config/package.json
+++ b/packages/xerox-eslint-config/package.json
@@ -7,7 +7,8 @@
     "eslint",
     "eslint-config",
     "typescript",
-    "react"
+    "react",
+    "jest"
   ],
   "main": "index.js",
   "repository": "git@github.com:xeroxinteractive/config.git",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/browserslist-config@1.1.0-next.0`
`@xerox/cli@0.2.0-next.0`
`@xerox/commitlint-config@2.3.0-next.0`
`@xerox/eslint-config@3.3.0-next.0`
`@xerox/prettier-config@2.3.0-next.0`
`@xerox/semantic-release-config@2.5.0-next.0`
`@xerox/stylelint-config@1.2.0-next.0`

<details>
  <summary>Changelog</summary>

  #### Feature
  
  - `@xerox/eslint-config`
    - Seperate out jest config [#652](https://github.com/xeroxinteractive/config/pull/652) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Dependencies
  
  - chore(deps): bump typescript from 4.2.2 to 4.2.3 [#651](https://github.com/xeroxinteractive/config/pull/651) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.18.1 to 10.18.3 [#650](https://github.com/xeroxinteractive/config/pull/650) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.18.1 to 10.18.3 [#649](https://github.com/xeroxinteractive/config/pull/649) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Andrew Leedham ([@AndrewLeedham](https://github.com/AndrewLeedham))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
