### PR TITLE
feat: disable jsdoc types for TS

### DIFF
--- a/packages/xerox-eslint-config/typescript.js
+++ b/packages/xerox-eslint-config/typescript.js
@@ -46,9 +46,15 @@ module.exports = {
         definedTags: ['remarks', 'jest-environment'],
       },
     ],
-    'jsdoc/check-types': 'warn',
-    'jsdoc/newline-after-description': 'error',
+
+    // Disable all the types related stuff, as that is what TypeScript is for.
+    'jsdoc/no-types': 'off',
+    'jsdoc/check-types': 'off',
     'jsdoc/no-undefined-types': 'off',
+    'jsdoc/require-returns-type': 'off',
+    'jsdoc/valid-types': 'off',
+
+    'jsdoc/newline-after-description': 'error',
     'jsdoc/require-description': 'off',
     'jsdoc/require-description-complete-sentence': 'error',
     'jsdoc/require-example': 'off',
@@ -60,8 +66,6 @@ module.exports = {
     'jsdoc/require-returns': 'error',
     'jsdoc/require-returns-check': 'error',
     'jsdoc/require-returns-description': 'error',
-    'jsdoc/require-returns-type': 'off',
-    'jsdoc/valid-types': 'off',
     'jsdoc/require-jsdoc': [
       'error',
       {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/eslint-config@3.3.0-next.1`
`@xerox/stylelint-config@1.2.0-next.1`

<details>
  <summary>Changelog</summary>

  #### Feature
  
  - `@xerox/eslint-config`
    - feat: disable jsdoc types for TS [#692](https://github.com/xeroxinteractive/config/pull/692) ([@AndrewLeedham](https://github.com/AndrewLeedham))
    - Seperate out jest config [#652](https://github.com/xeroxinteractive/config/pull/652) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Dependencies
  
  - chore(deps-dev): bump @auto-it/slack from 10.22.0 to 10.22.1 [#691](https://github.com/xeroxinteractive/config/pull/691) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-react from 7.22.0 to 7.23.1 [#690](https://github.com/xeroxinteractive/config/pull/690) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.22.0 to 10.22.1 [#689](https://github.com/xeroxinteractive/config/pull/689) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump globby from 11.0.2 to 11.0.3 [#688](https://github.com/xeroxinteractive/config/pull/688) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.21.0 to 10.22.0 [#685](https://github.com/xeroxinteractive/config/pull/685) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.18.0 to 4.19.0 [#687](https://github.com/xeroxinteractive/config/pull/687) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.18.0 to 4.19.0 [#686](https://github.com/xeroxinteractive/config/pull/686) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.21.0 to 10.22.0 [#684](https://github.com/xeroxinteractive/config/pull/684) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump react from 17.0.1 to 17.0.2 [#683](https://github.com/xeroxinteractive/config/pull/683) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.20.6 to 10.21.0 [#682](https://github.com/xeroxinteractive/config/pull/682) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-testing-library from 3.10.1 to 3.10.2 [#681](https://github.com/xeroxinteractive/config/pull/681) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.20.6 to 10.21.0 [#680](https://github.com/xeroxinteractive/config/pull/680) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.20.4 to 10.20.6 [#679](https://github.com/xeroxinteractive/config/pull/679) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.20.4 to 10.20.6 [#678](https://github.com/xeroxinteractive/config/pull/678) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.3.1 to 24.3.2 [#677](https://github.com/xeroxinteractive/config/pull/677) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.20.1 to 10.20.4 [#674](https://github.com/xeroxinteractive/config/pull/674) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.17.0 to 4.18.0 [#676](https://github.com/xeroxinteractive/config/pull/676) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jsdoc from 32.2.0 to 32.3.0 [#675](https://github.com/xeroxinteractive/config/pull/675) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.17.0 to 4.18.0 [#673](https://github.com/xeroxinteractive/config/pull/673) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.20.1 to 10.20.4 [#672](https://github.com/xeroxinteractive/config/pull/672) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.18.7 to 10.20.1 [#671](https://github.com/xeroxinteractive/config/pull/671) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.21.0 to 7.22.0 [#670](https://github.com/xeroxinteractive/config/pull/670) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.2.1 to 24.3.1 [#669](https://github.com/xeroxinteractive/config/pull/669) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.18.7 to 10.20.1 [#668](https://github.com/xeroxinteractive/config/pull/668) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.18.4 to 10.18.7 [#667](https://github.com/xeroxinteractive/config/pull/667) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.18.4 to 10.18.7 [#666](https://github.com/xeroxinteractive/config/pull/666) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.2.0 to 24.2.1 [#665](https://github.com/xeroxinteractive/config/pull/665) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.18.3 to 10.18.4 [#664](https://github.com/xeroxinteractive/config/pull/664) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @semantic-release/release-notes-generator from 9.0.1 to 9.0.2 [#659](https://github.com/xeroxinteractive/config/pull/659) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/eslint-plugin from 4.16.1 to 4.17.0 [#660](https://github.com/xeroxinteractive/config/pull/660) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @typescript-eslint/parser from 4.16.1 to 4.17.0 [#661](https://github.com/xeroxinteractive/config/pull/661) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.1.8 to 24.2.0 [#662](https://github.com/xeroxinteractive/config/pull/662) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.18.3 to 10.18.4 [#663](https://github.com/xeroxinteractive/config/pull/663) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/react from 17.0.2 to 17.0.3 [#656](https://github.com/xeroxinteractive/config/pull/656) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump stylelint from 13.11.0 to 13.12.0 [#655](https://github.com/xeroxinteractive/config/pull/655) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump eslint-plugin-jest from 24.1.5 to 24.1.8 [#653](https://github.com/xeroxinteractive/config/pull/653) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.2.2 to 4.2.3 [#651](https://github.com/xeroxinteractive/config/pull/651) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/slack from 10.18.1 to 10.18.3 [#650](https://github.com/xeroxinteractive/config/pull/650) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.18.1 to 10.18.3 [#649](https://github.com/xeroxinteractive/config/pull/649) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@xerox/stylelint-config`
    - chore(deps): bump stylelint-config-recommended from 3.0.0 to 4.0.0 [#654](https://github.com/xeroxinteractive/config/pull/654) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Andrew Leedham ([@AndrewLeedham](https://github.com/AndrewLeedham))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
