### PR TITLE
Resolve config path as URL

### DIFF
--- a/packages/xerox-cli/bin/x.js
+++ b/packages/xerox-cli/bin/x.js
@@ -3,6 +3,7 @@
 import { findUp } from 'find-up';
 import path from 'path';
 import chalk from 'chalk';
+import { pathToFileURL } from 'url';
 
 const configPath = await findUp([
   'x-cli.config.mjs',
@@ -10,7 +11,7 @@ const configPath = await findUp([
   'x-cli.config.js',
 ]);
 if (configPath) {
-  const url = new URL(`file:///${configPath}`);
+  const url = pathToFileURL(configPath);
   const { run } = await import(url.href);
   process.chdir(path.dirname(configPath));
   run();

--- a/packages/xerox-cli/bin/x.js
+++ b/packages/xerox-cli/bin/x.js
@@ -10,7 +10,8 @@ const configPath = await findUp([
   'x-cli.config.js',
 ]);
 if (configPath) {
-  const { run } = await import(configPath);
+  const url = new URL(`file:///${configPath}`);
+  const { run } = await import(url.href);
   process.chdir(path.dirname(configPath));
   run();
 } else {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/browserslist-config@2.1.0-next.0`
`@xerox/cli@1.1.1-next.0`
`@xerox/commitlint-config@3.1.1-next.0`
`@xerox/eslint-config@4.1.1-next.0`
`@xerox/prettier-config@3.1.0-next.0`
`@xerox/semantic-release-config@3.1.1-next.0`
`@xerox/stylelint-config@2.1.1-next.0`

<details>
  <summary>Changelog</summary>

  #### Fix
  
  - `@xerox/cli`
    - Resolve config path as URL [#1003](https://github.com/xeroxinteractive/config/pull/1003) ([@tinytim84](https://github.com/tinytim84))
  
  #### Dependencies
  
  - `@xerox/semantic-release-config`
    - Update all non-major dependencies [#1002](https://github.com/xeroxinteractive/config/pull/1002) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  - `@xerox/cli`
    - Update dependency @types/node to v16.11.22 [#1001](https://github.com/xeroxinteractive/config/pull/1001) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  
  #### Authors: 3
  
  - [@renovate[bot]](https://github.com/renovate[bot])
  - Tim Ottewell ([@tinytim84](https://github.com/tinytim84))
  - WhiteSource Renovate ([@renovate-bot](https://github.com/renovate-bot))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
