### PR TITLE
Fix prettier config exporting JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "./packages/xerox-eslint-config/index.js"
     ]
   },
-  "prettier": "./packages/xerox-prettier-config/index.json",
+  "prettier": "./packages/xerox-prettier-config/index.js",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/xerox-prettier-config/index.js
+++ b/packages/xerox-prettier-config/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  tabWidth: 2,
+  singleQuote: true,
+  arrowParens: 'always',
+  endOfLine: 'lf',
+  trailingComma: 'es5',
+};

--- a/packages/xerox-prettier-config/index.json
+++ b/packages/xerox-prettier-config/index.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "http://json.schemastore.org/prettierrc",
-  "tabWidth": 2,
-  "singleQuote": true,
-  "arrowParens": "always",
-  "endOfLine": "lf",
-  "trailingComma": "es5"
-}

--- a/packages/xerox-prettier-config/package.json
+++ b/packages/xerox-prettier-config/package.json
@@ -7,7 +7,7 @@
     "prettier",
     "prettier-config"
   ],
-  "main": "index.json",
+  "main": "index.js",
   "repository": "git@github.com:xeroxinteractive/config.git",
   "homepage": "https://github.com/xeroxinteractive/config/blob/master/packages/xerox-prettier-config",
   "author": "Andrew Leedham <andrew.leedham@xerox.com>",


### PR DESCRIPTION
JSON is not a valid export, ESM warns about it, also TS requires additional config for it to work in CJS. So moving to a JS export.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/cli@2.0.0-next.0`
`@xerox/commitlint-config@4.0.0-next.0`
`@xerox/eslint-config@5.0.0-next.0`
`@xerox/prettier-config@4.0.0-next.0`
`@xerox/semantic-release-config@4.0.0-next.0`
`@xerox/stylelint-config@3.0.0-next.0`

<details>
  <summary>Changelog</summary>

  #### Breaking Change
  
  - `@xerox/prettier-config`
    - Fix prettier config exporting JSON [#1020](https://github.com/xeroxinteractive/config/pull/1020) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Dependencies
  
  - `@xerox/cli`
    - Update dependency @types/node to v16.11.26 [#1017](https://github.com/xeroxinteractive/config/pull/1017) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  - `@xerox/semantic-release-config`
    - Update dependency @semantic-release/npm to v9.0.1 [#1016](https://github.com/xeroxinteractive/config/pull/1016) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  - `@xerox/cli`, `@xerox/eslint-config`, `@xerox/stylelint-config`
    - Update all non-major dependencies [#1015](https://github.com/xeroxinteractive/config/pull/1015) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  
  #### Authors: 3
  
  - [@renovate[bot]](https://github.com/renovate[bot])
  - Andrew Leedham ([@AndrewLeedham](https://github.com/AndrewLeedham))
  - WhiteSource Renovate ([@renovate-bot](https://github.com/renovate-bot))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
