### PR TITLE
Add prettier config types

### DIFF
--- a/packages/xerox-prettier-config/index.d.ts
+++ b/packages/xerox-prettier-config/index.d.ts
@@ -1,0 +1,3 @@
+import { Config } from 'prettier';
+declare const prettierConfig: Config;
+export = prettierConfig;

--- a/packages/xerox-prettier-config/package.json
+++ b/packages/xerox-prettier-config/package.json
@@ -8,12 +8,16 @@
     "prettier-config"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "git@github.com:xeroxinteractive/config.git",
   "homepage": "https://github.com/xeroxinteractive/config/blob/master/packages/xerox-prettier-config",
   "author": "Andrew Leedham <andrew.leedham@xerox.com>",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@types/prettier": "*"
   },
   "peerDependencies": {
     "prettier": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2290,6 +2290,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prettier@*":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
+  integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
+
 "@types/prettier@^2.1.5":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"


### PR DESCRIPTION
Add types to prettier config
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@xerox/prettier-config@4.0.0-next.1`
`@xerox/stylelint-config@3.0.0-next.1`

<details>
  <summary>Changelog</summary>

  #### Breaking Change
  
  - `@xerox/prettier-config`
    - Fix prettier config exporting JSON [#1020](https://github.com/xeroxinteractive/config/pull/1020) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Feature
  
  - `@xerox/prettier-config`
    - Add prettier config types [#1021](https://github.com/xeroxinteractive/config/pull/1021) ([@AndrewLeedham](https://github.com/AndrewLeedham))
  
  #### Dependencies
  
  - `@xerox/cli`
    - Update dependency @types/node to v16.11.26 [#1017](https://github.com/xeroxinteractive/config/pull/1017) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  - `@xerox/semantic-release-config`
    - Update dependency @semantic-release/npm to v9.0.1 [#1016](https://github.com/xeroxinteractive/config/pull/1016) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  - `@xerox/cli`, `@xerox/eslint-config`, `@xerox/stylelint-config`
    - Update all non-major dependencies [#1015](https://github.com/xeroxinteractive/config/pull/1015) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
  
  #### Authors: 3
  
  - [@renovate[bot]](https://github.com/renovate[bot])
  - Andrew Leedham ([@AndrewLeedham](https://github.com/AndrewLeedham))
  - WhiteSource Renovate ([@renovate-bot](https://github.com/renovate-bot))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
